### PR TITLE
Removes unused import "Platform"

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { Component } from 'react';
-import { Dimensions, FlatList, PanResponder, Platform } from 'react-native';
+import { Dimensions, FlatList, PanResponder } from 'react-native';
 
 import type { CarouselProps, GestureEvent, GestureState } from '../types';
 


### PR DESCRIPTION
I noticed that "Platform" was imported but wasn't used in the module (yet?).