### PR TITLE
Check for undefined index instead of falsy

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -81,7 +81,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
   };
 
   componentWillReceiveProps = (nextProps: CarouselProps) => {
-    if (nextProps.index && nextProps.index !== this.state.currentIndex) {
+    if (typeof nextProps.index !== 'undefined' && nextProps.index !== this.state.currentIndex) {
       this.setState(
         () => ({ currentIndex: nextProps.index }),
         () => {


### PR DESCRIPTION
### What did you do:
Currently, in the `componentWillReceiveProps` function of the carousel component, you check if `nextProps.index` is falsy and if it's different than the currentIndex. When you try to update the index to 0, `nextProps.index` is falsy, and the carousel doesn't scroll. Checking for `typeof nextProps.index !== 'undefined' ` instead should solve this issue.

### Checklist:

- [x] I added link to related issue if there is one
- [x] I added a screenshot/gif (if appropriate)
- [x] I ran `yarn lint` and `yarn flow`