### PR TITLE
add useVelocityForIndex as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ type CarouselProps = {
    * 0 -index ----- 100 ----- +index 200
    */
 
+  // to determine the index use the velocity of the gesture.
+  useVelocityForIndex?: boolean,
+
   // render item method, similar to FlatList with some enhancements
   renderItem: CarouselRenderProps =>
     | Array<React$Element<*> | boolean>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sideswipe",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "cross-platform react native carousel with sensible defaults",
   "main": "src/index.js",
   "repository": "https://github.com/kkemple/react-native-sideswipe",

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -190,7 +190,6 @@ export default class SideSwipe extends Component<CarouselProps, State> {
         this.props.itemWidth
     );
 
-
     let newIndex: number;
     if (this.props.useVelocityForIndex) {
       const absoluteVelocity: number = Math.round(Math.abs(vx));
@@ -205,7 +204,13 @@ export default class SideSwipe extends Component<CarouselProps, State> {
               this.props.data.length - 1
             );
     } else {
-      newIndex = resolvedIndex;
+      newIndex =
+        dx > 0
+          ? Math.max(resolvedIndex, 0)
+          : Math.min(
+              resolvedIndex,
+              this.props.data.length - 1
+            ); 
     }
 
     this.list.scrollToIndex({

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -42,6 +42,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     shouldCapture: ({ dx }: GestureState) => Math.abs(dx) > 1,
     shouldRelease: () => false,
     threshold: 0,
+    useVelocityForIndex: true,
     useNativeDriver: true,
   };
 
@@ -189,17 +190,23 @@ export default class SideSwipe extends Component<CarouselProps, State> {
         this.props.itemWidth
     );
 
-    const absoluteVelocity: number = Math.round(Math.abs(vx));
-    const velocityDifference: number =
-      absoluteVelocity < 1 ? 0 : absoluteVelocity - 1;
 
-    const newIndex: number =
-      dx > 0
-        ? Math.max(resolvedIndex - velocityDifference, 0)
-        : Math.min(
-            resolvedIndex + velocityDifference,
-            this.props.data.length - 1
-          );
+    let newIndex: number;
+    if (this.props.useVelocityForIndex) {
+      const absoluteVelocity: number = Math.round(Math.abs(vx));
+      const velocityDifference: number =
+        absoluteVelocity < 1 ? 0 : absoluteVelocity - 1;
+
+      newIndex =
+        dx > 0
+          ? Math.max(resolvedIndex - velocityDifference, 0)
+          : Math.min(
+              resolvedIndex + velocityDifference,
+              this.props.data.length - 1
+            );
+    } else {
+      newIndex = resolvedIndex;
+    }
 
     this.list.scrollToIndex({
       index: newIndex,


### PR DESCRIPTION
### What did you do:
I added a prop useVelocityForIndex that is by default true.
If its set to true then the normal behaviour will happen and if the velocity is fast the carousel is moving more then one slide. For some projects you dont want to do that and the carousel should only move 1 slide and don't count in the velocity of the swipe. 

If you set the useVelocityForIndex to false then the carousel will ignore the velocity and just go to the next or the previous slide.

### Checklist:
<!-- Go over all the following points, before creating a PR -->


- [x] I added link to related issue if there is one (is none)
- [x] I added a screenshot/gif (if appropriate)
- [x] I ran `yarn lint` and `yarn flow`

I didnt have any problems with `yarn lint` but I do with `yarn flow`... it also gives errors on things i didn't change. Also I don't know how to fix that. Can you help me with that? @kkemple 