### PR TITLE
add option to disable the animation in scrollToIndex when gestureRele…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ type CarouselProps = {
   // to determine the index use the velocity of the gesture.
   useVelocityForIndex?: boolean,
 
+  // if gesture is released and the carousel is scrolling to the slide. Do we need to animate to the slide (true) or snap to the right slide (false)
+  gestureReleaseAnimated?: boolean,
+
   // render item method, similar to FlatList with some enhancements
   renderItem: CarouselRenderProps =>
     | Array<React$Element<*> | boolean>

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -43,6 +43,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     shouldRelease: () => false,
     threshold: 0,
     useVelocityForIndex: true,
+    gestureReleaseAnimated: true,
     useNativeDriver: true,
   };
 
@@ -212,7 +213,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
 
     this.list.scrollToIndex({
       index: newIndex,
-      animated: true,
+      animated: this.props.gestureReleaseAnimated,
       viewOffset: this.props.contentOffset,
     });
 


### PR DESCRIPTION
### What did you do:
I noticed that the slider feels a little bit slow when the gestureRelease triggers.
It was because of the animation in the scrollToIndex. So I added a option to disable that if you dont want the animation.

### Maybe a good idea?
Dont know if it is a good idea to have this as a default behaviour? Then the carousel is fast for everyone.

### Does this relate to any issue(s)? If so which one(s)?
nope

### Checklist:

- [x] I added link to related issue if there is one
- [x] I added a screenshot/gif (if appropriate)
- [x] I ran `yarn lint` and `yarn flow`

still in yarn flow things break and dont know how to fix that? can you explain that?