### PR TITLE
pass gesture start and release events to the parent

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -37,6 +37,8 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     itemWidth: screenWidth,
     onEndReached: () => {},
     onEndReachedThreshold: 0.9,
+    onGestureStart: () => {},
+    onGestureRelease: () => {},
     onIndexChange: () => {},
     renderItem: () => null,
     shouldCapture: ({ dx }: GestureState) => Math.abs(dx) > 1,
@@ -69,6 +71,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
   componentWillMount = (): void => {
     this.panResponder = PanResponder.create({
       onMoveShouldSetPanResponder: this.handleGestureCapture,
+      onPanResponderGrant: this.handleGestureStart,
       onPanResponderMove: this.handleGestureMove,
       onPanResponderRelease: this.handleGestureRelease,
       onPanResponderTerminationRequest: this.handleGestureTerminationRequest,
@@ -169,6 +172,9 @@ export default class SideSwipe extends Component<CarouselProps, State> {
   handleGestureCapture = (e: GestureEvent, s: GestureState) =>
     this.props.shouldCapture(s);
 
+  handleGestureStart = (e: GestureEvent, s: GestureState) =>
+    this.props.onGestureStart(s);
+
   handleGestureMove = (e: GestureEvent, { dx }: GestureState) => {
     const currentOffset: number =
       this.state.currentIndex * this.props.itemWidth;
@@ -218,7 +224,10 @@ export default class SideSwipe extends Component<CarouselProps, State> {
 
     this.setState(
       () => ({ currentIndex: newIndex }),
-      () => this.props.onIndexChange(newIndex),
+      () => {
+        this.props.onIndexChange(newIndex);
+        this.props.onGestureRelease();
+      },
     );
   };
 }


### PR DESCRIPTION
### What did you do:
Pass start and finish gesture events to the parent

### Does this relate to any issue(s)? If so which one(s)?
This will help solve UX issues while using this swiper inside a ScrollView component. The parent can now stop/start scrolling using these events.

https://github.com/kkemple/react-native-sideswipe/issues/34

Usage: 

```
<ScrollView scrollEnabled={this.state.scrollEnabled}>
  ...
  <SideSwipe
    ...
    onGestureStart={() => {
      this.setState({ scrollEnabled: false })
    }}
    onGestureRelease={() => {
      this.setState({ scrollEnabled: true })
    }}
  />
</ScrollView>
```