### PR TITLE
Avoid running Math.abs() in capturegesture

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -39,7 +39,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     onEndReachedThreshold: 0.9,
     onIndexChange: () => {},
     renderItem: () => null,
-    shouldCapture: ({ dx }: GestureState) => Math.abs(dx) > 1,
+    shouldCapture: ({ dx }: GestureState) => (dx * dx) > 1,
     shouldRelease: () => false,
     threshold: 0,
     useVelocityForIndex: true,


### PR DESCRIPTION
It's a tiny performance improvement. The comparison ends up being identical to the previous one, but it avoid the rather expensive Math.abs() call.

Feel free to merge or close this, I just wanted to point it out and provide a PR in case y'all wanted it. :)