### PR TITLE
Fix RTL swipe direction

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -7,6 +7,7 @@ import {
   FlatList,
   PanResponder,
   StyleSheet,
+  I18nManager,
 } from 'react-native';
 
 import type {
@@ -16,6 +17,7 @@ import type {
   ScrollEvent,
 } from '../types';
 
+const { isRTL } = I18nManager;
 const { width: screenWidth } = Dimensions.get('window');
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 
@@ -175,6 +177,9 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     this.props.onGestureStart(s);
 
   handleGestureMove = (e: GestureEvent, { dx }: GestureState) => {
+    if (isRTL) {
+      dx *= -1
+    }
     const currentOffset: number =
       this.state.currentIndex * this.props.itemWidth;
     const resolvedOffset: number = currentOffset - dx;
@@ -186,6 +191,10 @@ export default class SideSwipe extends Component<CarouselProps, State> {
   };
 
   handleGestureRelease = (e: GestureEvent, { dx, vx }: GestureState) => {
+    if (isRTL) {
+      dx *= -1
+      vx *= -1
+    }
     const currentOffset: number =
       this.state.currentIndex * this.props.itemWidth;
     const resolvedOffset: number = currentOffset - dx;


### PR DESCRIPTION
### What did you do:

Fixed RTL swipe direction by negating `dx` and `vx` in the methods that calculate the offset.

### Does this relate to any issue(s)? If so which one(s)?

Issue #26 

### Screenshots:

![slideswipe rtl](https://user-images.githubusercontent.com/12089120/68878054-12b6ec00-06d5-11ea-8a14-ca96084f2d18.gif)

### Checklist:
<!-- Go over all the following points, before creating a PR -->

- [X] I added link to related issue if there is one
- [X] I added a screenshot/gif (if appropriate)
- [   ] I ran `yarn lint` and `yarn flow`